### PR TITLE
refactor: use event for request and user data

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -20,19 +20,18 @@ from interface.alexa_adapter import (
 
 def lambda_handler(event, context):
     """Entrypoint for AWS Lambda invoked by Alexa."""
-    data = event
-    intent = data["request"]["intent"]["name"]
-    user_id = data["session"]["user"]["userId"]
+    intent = event["request"]["intent"]["name"]
+    user_id = event["session"]["user"]["userId"]
 
     if intent == "SuggestDinnerIntent":
         return handle_meal_intent("dinner", user_id)
 
     elif intent == "AddLunchIntent":
-        dish = data["request"]["intent"]["slots"]["dish"]["value"]
+        dish = event["request"]["intent"]["slots"]["dish"]["value"]
         return handle_add_meal_intent("lunch", dish, user_id)
 
     elif intent == "AddDinnerIntent":
-        dish = data["request"]["intent"]["slots"]["dish"]["value"]
+        dish = event["request"]["intent"]["slots"]["dish"]["value"]
         return handle_add_meal_intent("dinner", dish, user_id)
 
     elif intent == "RecommendDinnerIntent":
@@ -48,17 +47,17 @@ def lambda_handler(event, context):
         return handle_no_intent(user_id)
 
     elif intent == "AddToMealListIntent":
-        meal_type = data["request"]["intent"]["slots"]["meal_type"]["value"]
-        dish = data["request"]["intent"]["slots"]["dish"]["value"]
+        meal_type = event["request"]["intent"]["slots"]["meal_type"]["value"]
+        dish = event["request"]["intent"]["slots"]["dish"]["value"]
         return handle_add_to_meal_list_intent(meal_type, dish, user_id)
 
     elif intent == "RemoveFromMealListIntent":
-        meal_type = data["request"]["intent"]["slots"]["meal_type"]["value"]
-        dish = data["request"]["intent"]["slots"]["dish"]["value"]
+        meal_type = event["request"]["intent"]["slots"]["meal_type"]["value"]
+        dish = event["request"]["intent"]["slots"]["dish"]["value"]
         return handle_remove_from_meal_list_intent(meal_type, dish, user_id)
 
     elif intent == "SuggestAddFromRecipeIntent":
-        dish = data["request"]["intent"]["slots"]["dish"]["value"]
+        dish = event["request"]["intent"]["slots"]["dish"]["value"]
         return handle_suggest_add_from_recipe_intent(dish)
 
     return {}


### PR DESCRIPTION
## Summary
- Extract intent name from event path
- Extract user id from event session structure

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ff06678648333823ab25727ed22bc