### PR TITLE
fix: include language model structure

### DIFF
--- a/models/en-US.json
+++ b/models/en-US.json
@@ -1,70 +1,78 @@
 {
-  "intents": [
-    {
-      "name": "SuggestDinnerIntent",
-      "samples": ["suggest a dinner", "I want a dinner suggestion"]
-    },
-    {
-      "name": "AddDinnerIntent",
-      "samples": ["add {dish} to my dinners", "add {dish} for dinner"],
-      "slots": [
-        {"name": "dish", "type": "AMAZON.Food"}
-      ]
-    },
-    {
-      "name": "AddLunchIntent",
-      "samples": ["add {dish} to my lunches", "add {dish} for lunch"],
-      "slots": [
-        {"name": "dish", "type": "AMAZON.Food"}
-      ]
-    },
-    {
-      "name": "RecommendDinnerIntent",
-      "samples": ["recommend a dinner", "give me a dinner recommendation"]
-    },
-    {
-      "name": "RandomDinnerIntent",
-      "samples": ["random dinner", "surprise me with dinner"]
-    },
-    {
-      "name": "YesIntent",
-      "samples": ["yes", "I like it", "sure"]
-    },
-    {
-      "name": "NoIntent",
-      "samples": ["no", "another one", "I don't like it"]
-    },
-    {
-      "name": "AddToMealListIntent",
-      "samples": ["add {dish} to my {meal_type}", "set {dish} as {meal_type}"],
-      "slots": [
-        {"name": "dish", "type": "AMAZON.Food"},
-        {"name": "meal_type", "type": "MealType"}
-      ]
-    },
-    {
-      "name": "RemoveFromMealListIntent",
-      "samples": ["remove {dish} from my {meal_type}", "delete {dish} from my {meal_type}"],
-      "slots": [
-        {"name": "dish", "type": "AMAZON.Food"},
-        {"name": "meal_type", "type": "MealType"}
-      ]
-    },
-    {
-      "name": "SuggestAddFromRecipeIntent",
-      "samples": ["give me the recipe for {dish}", "I want the recipe for {dish}"],
-      "slots": [
-        {"name": "dish", "type": "AMAZON.Food"}
+  "interactionModel": {
+    "languageModel": {
+      "invocationName": "meal suggester",
+      "intents": [
+        {"name": "AMAZON.CancelIntent", "samples": []},
+        {"name": "AMAZON.HelpIntent", "samples": []},
+        {"name": "AMAZON.StopIntent", "samples": []},
+        {
+          "name": "SuggestDinnerIntent",
+          "samples": ["suggest a dinner", "I want a dinner suggestion"]
+        },
+        {
+          "name": "AddDinnerIntent",
+          "samples": ["add {dish} to my dinners", "add {dish} for dinner"],
+          "slots": [
+            {"name": "dish", "type": "AMAZON.Food"}
+          ]
+        },
+        {
+          "name": "AddLunchIntent",
+          "samples": ["add {dish} to my lunches", "add {dish} for lunch"],
+          "slots": [
+            {"name": "dish", "type": "AMAZON.Food"}
+          ]
+        },
+        {
+          "name": "RecommendDinnerIntent",
+          "samples": ["recommend a dinner", "give me a dinner recommendation"]
+        },
+        {
+          "name": "RandomDinnerIntent",
+          "samples": ["random dinner", "surprise me with dinner"]
+        },
+        {
+          "name": "YesIntent",
+          "samples": ["yes", "I like it", "sure"]
+        },
+        {
+          "name": "NoIntent",
+          "samples": ["no", "another one", "I don't like it"]
+        },
+        {
+          "name": "AddToMealListIntent",
+          "samples": ["add {dish} to my {meal_type}", "set {dish} as {meal_type}"],
+          "slots": [
+            {"name": "dish", "type": "AMAZON.Food"},
+            {"name": "meal_type", "type": "MealType"}
+          ]
+        },
+        {
+          "name": "RemoveFromMealListIntent",
+          "samples": ["remove {dish} from my {meal_type}", "delete {dish} from my {meal_type}"],
+          "slots": [
+            {"name": "dish", "type": "AMAZON.Food"},
+            {"name": "meal_type", "type": "MealType"}
+          ]
+        },
+        {
+          "name": "SuggestAddFromRecipeIntent",
+          "samples": ["give me the recipe for {dish}", "I want the recipe for {dish}"],
+          "slots": [
+            {"name": "dish", "type": "AMAZON.Food"}
+          ]
+        }
+      ],
+      "types": [
+        {
+          "name": "MealType",
+          "values": [
+            {"name": {"value": "lunch"}},
+            {"name": {"value": "dinner"}}
+          ]
+        }
       ]
     }
-  ],
-  "types": [
-    {
-      "name": "MealType",
-      "values": [
-        {"name": {"value": "lunch"}},
-        {"name": {"value": "dinner"}}
-      ]
-    }
-  ]
+  }
 }

--- a/models/es-ES.json
+++ b/models/es-ES.json
@@ -1,70 +1,78 @@
 {
-  "intents": [
-    {
-      "name": "SuggestDinnerIntent",
-      "samples": ["sugiéreme una cena", "quiero una sugerencia de cena"]
-    },
-    {
-      "name": "AddDinnerIntent",
-      "samples": ["añade {dish} a mis cenas", "pon {dish} para cenar"],
-      "slots": [
-        {"name": "dish", "type": "AMAZON.Food"}
-      ]
-    },
-    {
-      "name": "AddLunchIntent",
-      "samples": ["añade {dish} a mis comidas", "pon {dish} para comer"],
-      "slots": [
-        {"name": "dish", "type": "AMAZON.Food"}
-      ]
-    },
-    {
-      "name": "RecommendDinnerIntent",
-      "samples": ["recomiéndame una cena", "dame una recomendación de cena"]
-    },
-    {
-      "name": "RandomDinnerIntent",
-      "samples": ["dame una cena al azar", "sorpréndeme con una cena"]
-    },
-    {
-      "name": "YesIntent",
-      "samples": ["sí", "me gusta", "vale"]
-    },
-    {
-      "name": "NoIntent",
-      "samples": ["no", "otra", "no me gusta"]
-    },
-    {
-      "name": "AddToMealListIntent",
-      "samples": ["añade {dish} a {meal_type}", "pon {dish} como {meal_type}"],
-      "slots": [
-        {"name": "dish", "type": "AMAZON.Food"},
-        {"name": "meal_type", "type": "MealType"}
-      ]
-    },
-    {
-      "name": "RemoveFromMealListIntent",
-      "samples": ["elimina {dish} de {meal_type}", "quita {dish} de {meal_type}"],
-      "slots": [
-        {"name": "dish", "type": "AMAZON.Food"},
-        {"name": "meal_type", "type": "MealType"}
-      ]
-    },
-    {
-      "name": "SuggestAddFromRecipeIntent",
-      "samples": ["quiero la receta de {dish}", "dame la receta de {dish}"],
-      "slots": [
-        {"name": "dish", "type": "AMAZON.Food"}
+  "interactionModel": {
+    "languageModel": {
+      "invocationName": "sugeridor de comidas",
+      "intents": [
+        {"name": "AMAZON.CancelIntent", "samples": []},
+        {"name": "AMAZON.HelpIntent", "samples": []},
+        {"name": "AMAZON.StopIntent", "samples": []},
+        {
+          "name": "SuggestDinnerIntent",
+          "samples": ["sugiéreme una cena", "quiero una sugerencia de cena"]
+        },
+        {
+          "name": "AddDinnerIntent",
+          "samples": ["añade {dish} a mis cenas", "pon {dish} para cenar"],
+          "slots": [
+            {"name": "dish", "type": "AMAZON.Food"}
+          ]
+        },
+        {
+          "name": "AddLunchIntent",
+          "samples": ["añade {dish} a mis comidas", "pon {dish} para comer"],
+          "slots": [
+            {"name": "dish", "type": "AMAZON.Food"}
+          ]
+        },
+        {
+          "name": "RecommendDinnerIntent",
+          "samples": ["recomiéndame una cena", "dame una recomendación de cena"]
+        },
+        {
+          "name": "RandomDinnerIntent",
+          "samples": ["dame una cena al azar", "sorpréndeme con una cena"]
+        },
+        {
+          "name": "YesIntent",
+          "samples": ["sí", "me gusta", "vale"]
+        },
+        {
+          "name": "NoIntent",
+          "samples": ["no", "otra", "no me gusta"]
+        },
+        {
+          "name": "AddToMealListIntent",
+          "samples": ["añade {dish} a {meal_type}", "pon {dish} como {meal_type}"],
+          "slots": [
+            {"name": "dish", "type": "AMAZON.Food"},
+            {"name": "meal_type", "type": "MealType"}
+          ]
+        },
+        {
+          "name": "RemoveFromMealListIntent",
+          "samples": ["elimina {dish} de {meal_type}", "quita {dish} de {meal_type}"],
+          "slots": [
+            {"name": "dish", "type": "AMAZON.Food"},
+            {"name": "meal_type", "type": "MealType"}
+          ]
+        },
+        {
+          "name": "SuggestAddFromRecipeIntent",
+          "samples": ["quiero la receta de {dish}", "dame la receta de {dish}"],
+          "slots": [
+            {"name": "dish", "type": "AMAZON.Food"}
+          ]
+        }
+      ],
+      "types": [
+        {
+          "name": "MealType",
+          "values": [
+            {"name": {"value": "comida"}},
+            {"name": {"value": "cena"}}
+          ]
+        }
       ]
     }
-  ],
-  "types": [
-    {
-      "name": "MealType",
-      "values": [
-        {"name": {"value": "comida"}},
-        {"name": {"value": "cena"}}
-      ]
-    }
-  ]
+  }
 }


### PR DESCRIPTION
## Summary
- wrap English interaction model with languageModel and invocation name
- add Spanish language model wrapper and invocation name

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ffe10ec30833384873beff5e5fbed