### PR TITLE
Handle LaunchRequest and add built-in intent utterances

### DIFF
--- a/lambda/interface/alexa_adapter.py
+++ b/lambda/interface/alexa_adapter.py
@@ -33,6 +33,14 @@ def alexa_response(text: str, end_session: bool = False):
         }
     }
 
+
+def handle_launch_request():
+    """Provides a greeting when the skill is invoked."""
+    return alexa_response(
+        "Hola. Pídeme una sugerencia de comida o añade un plato a tu lista.",
+        end_session=False,
+    )
+
 def handle_meal_intent(meal_type: str, user_id: str):
     """
     Handles intent to suggest a meal.

--- a/lambda/lambda_function.py
+++ b/lambda/lambda_function.py
@@ -3,6 +3,7 @@
 import logging
 
 from .interface.alexa_adapter import (
+    handle_launch_request,
     handle_meal_intent,
     handle_add_meal_intent,
     handle_recommend_meal_intent,
@@ -20,8 +21,18 @@ logger.setLevel(logging.INFO)
 
 def lambda_handler(event, context):
     """Entrypoint for AWS Lambda invoked by Alexa."""
-    intent = event["request"]["intent"]["name"]
+    request_type = event["request"]["type"]
     user_id = event["session"]["user"]["userId"]
+
+    if request_type == "LaunchRequest":
+        logger.info("LaunchRequest from user %s", user_id)
+        return handle_launch_request()
+
+    if request_type != "IntentRequest":
+        logger.warning("Unsupported request type %s", request_type)
+        return {}
+
+    intent = event["request"]["intent"]["name"]
     logger.info("Received intent %s from user %s", intent, user_id)
 
     if intent == "SuggestDinnerIntent":

--- a/models/en-US.json
+++ b/models/en-US.json
@@ -3,9 +3,9 @@
     "languageModel": {
       "invocationName": "meal suggester",
       "intents": [
-        {"name": "AMAZON.CancelIntent", "samples": []},
-        {"name": "AMAZON.HelpIntent", "samples": []},
-        {"name": "AMAZON.StopIntent", "samples": []},
+        {"name": "AMAZON.CancelIntent", "samples": ["cancel"]},
+        {"name": "AMAZON.HelpIntent", "samples": ["help"]},
+        {"name": "AMAZON.StopIntent", "samples": ["stop"]},
         {
           "name": "SuggestDinnerIntent",
           "samples": ["suggest a dinner", "I want a dinner suggestion"]

--- a/models/es-ES.json
+++ b/models/es-ES.json
@@ -3,9 +3,9 @@
     "languageModel": {
       "invocationName": "sugeridor de comidas",
       "intents": [
-        {"name": "AMAZON.CancelIntent", "samples": []},
-        {"name": "AMAZON.HelpIntent", "samples": []},
-        {"name": "AMAZON.StopIntent", "samples": []},
+        {"name": "AMAZON.CancelIntent", "samples": ["cancelar"]},
+        {"name": "AMAZON.HelpIntent", "samples": ["ayuda"]},
+        {"name": "AMAZON.StopIntent", "samples": ["para"]},
         {
           "name": "SuggestDinnerIntent",
           "samples": ["sugiéreme una cena", "quiero una sugerencia de cena"]


### PR DESCRIPTION
## Summary
- Add LaunchRequest greeting handler and guard for non-intent requests
- Supply sample phrases for built-in intents in both language models

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68906e0c616883338ef4be76c8cbbf4a