### PR TITLE
Handle LaunchRequest and FallbackIntent

### DIFF
--- a/lambda/interface/alexa_adapter.py
+++ b/lambda/interface/alexa_adapter.py
@@ -37,7 +37,15 @@ def alexa_response(text: str, end_session: bool = False):
 def handle_launch_request():
     """Provides a greeting when the skill is invoked."""
     return alexa_response(
-        "Hola. Pídeme una sugerencia de comida o añade un plato a tu lista.",
+        "Hola, soy tu asistente de comidas. ¿Quieres una sugerencia de cena o añadir un plato?",
+        end_session=False,
+    )
+
+
+def handle_fallback_intent():
+    """Handles unmatched utterances."""
+    return alexa_response(
+        "Lo siento, no he entendido eso. Puedes pedirme una sugerencia de cena, por ejemplo.",
         end_session=False,
     )
 

--- a/lambda/lambda_function.py
+++ b/lambda/lambda_function.py
@@ -13,6 +13,7 @@ from .interface.alexa_adapter import (
     handle_add_to_meal_list_intent,
     handle_remove_from_meal_list_intent,
     handle_suggest_add_from_recipe_intent,
+    handle_fallback_intent,
 )
 
 logger = logging.getLogger(__name__)
@@ -71,6 +72,9 @@ def lambda_handler(event, context):
     elif intent == "SuggestAddFromRecipeIntent":
         dish = event["request"]["intent"]["slots"]["dish"]["value"]
         return handle_suggest_add_from_recipe_intent(dish)
+
+    elif intent == "AMAZON.FallbackIntent":
+        return handle_fallback_intent()
 
     logger.warning("Unknown intent %s", intent)
     return {}

--- a/models/en-US.json
+++ b/models/en-US.json
@@ -6,6 +6,7 @@
         {"name": "AMAZON.CancelIntent", "samples": ["cancel"]},
         {"name": "AMAZON.HelpIntent", "samples": ["help"]},
         {"name": "AMAZON.StopIntent", "samples": ["stop"]},
+        {"name": "AMAZON.FallbackIntent", "samples": ["i don't know", "what did you say", "that's not it"]},
         {
           "name": "SuggestDinnerIntent",
           "samples": ["suggest a dinner", "I want a dinner suggestion"]

--- a/models/es-ES.json
+++ b/models/es-ES.json
@@ -6,6 +6,7 @@
         {"name": "AMAZON.CancelIntent", "samples": ["cancelar"]},
         {"name": "AMAZON.HelpIntent", "samples": ["ayuda"]},
         {"name": "AMAZON.StopIntent", "samples": ["para"]},
+        {"name": "AMAZON.FallbackIntent", "samples": ["no sé", "qué has dicho", "eso no"]},
         {
           "name": "SuggestDinnerIntent",
           "samples": ["sugiéreme una cena", "quiero una sugerencia de cena"]


### PR DESCRIPTION
## Summary
- greet users on skill launch with a friendly message
- handle unmatched utterances via FallbackIntent
- register the fallback intent in Spanish and English models

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68907236d73c833388dc87dbb8a519f2